### PR TITLE
Update Support Library to v28

### DIFF
--- a/share-plugin/gradle.conf
+++ b/share-plugin/gradle.conf
@@ -1,2 +1,2 @@
 [dependencies]
-    api ('com.android.support:support-v4:27.+')
+    api ('com.android.support:support-v4:28.+')


### PR DESCRIPTION
The Support Library v27 results in build failure in Godot 3.2 Stable. Changing this to v28 fixes the issue.